### PR TITLE
Don't add automerge label in Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,7 @@ updates:
       interval: daily
     ignore:
       - dependency-name: "homeassistant"
-    labels:
-      - "dependencies"
-      - "automerge"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    labels:
-      - "dependencies"
-      - "automerge"

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -3,6 +3,9 @@ version = 1
 [approve]
 auto_approve_usernames = ["dependabot"]
 
+[merge]
+method = "squash"
+
 [merge.automerge_dependencies]
 versions = ["minor", "patch"]
 usernames = ["dependabot"]


### PR DESCRIPTION
If I understand it correctly, it shouldn't be needed.