### PR TITLE
Require Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Generate and publish
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 homeassistant = "2021.12.10"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Home Assistant now requires at least Python 3.9.