### PR TITLE
Skip package creation if HA is not published on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,12 @@ multi_line_output = 3
 max-line-length = "88"
 
 [tool.pylint.basic]
-good-names = ["ex", "fp"]
+good-names = ["ex", "fp", "i"]
+
+[tool.pylint.messages_control]
+disable = [
+    "too-many-arguments",
+]
 
 [tool.mypy]
 python_version = 3.8


### PR DESCRIPTION
Sometimes the script is run before new version is published on PyPI.

Fixes #163 