### PR TITLE
Forbid Python 3.13 to resolve dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ packages = [
 "Release Notes" = "https://github.com/KapJI/homeassistant-stubs/releases"
 
 [tool.poetry.dependencies]
-python = "^3.11"
+# Forbid 3.13 because of home-assistant-bluetooth package.
+python = ">=3.11,<3.13"
 homeassistant = "2023.12.4"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
https://github.com/home-assistant-libs/home-assistant-bluetooth forbids Python 3.13 and dependency resolution fails.