### PR TITLE
Allow Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 keywords = ["homeassistant", "typing", "pep484"]
-# Forbid 3.13 because of home-assistant-bluetooth package.
-requires-python = ">=3.12,<3.13"
+# Forbid 3.14 because of home-assistant-bluetooth package.
+requires-python = ">=3.12,<3.14"
 dynamic = ["version"]
 dependencies = [
     "homeassistant==2024.10.1",


### PR DESCRIPTION
The latest release of `home-assistant-bluetooth` supports Python 3.13.
https://github.com/home-assistant-libs/home-assistant-bluetooth/releases/tag/v1.13.0
https://github.com/home-assistant/core/pull/127691