### PR TITLE
Use official astral-sh/setup-uv caching

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
-        version: "0.4.23"
+        version: "0.4.20"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -17,7 +17,7 @@ runs:
     #     version: "0.4.23"
     - name: Install uv
       shell: bash
-      run: cargo install --git https://github.com/astral-sh/uv --rev 7730861bc5c6fb58ad402a396479f2cba6946110 uv
+      run: cargo install --git https://github.com/astral-sh/uv --rev 6a81d302bbc03bcb5bad4e6da44f4a0472f102b4 uv
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -3,21 +3,11 @@ name: "Common steps to install and cache dependencies"
 runs:
   using: "composite"
   steps:
-    - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-
-    # - name: Install uv
-    #   uses: astral-sh/setup-uv@v3
-    #   with:
-    #     enable-cache: true
-    #     version: "0.4.23"
     - name: Install uv
-      shell: bash
-      run: cargo install --git https://github.com/astral-sh/uv --rev 6a81d302bbc03bcb5bad4e6da44f4a0472f102b4 uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+        version: "0.4.22"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -3,11 +3,21 @@ name: "Common steps to install and cache dependencies"
 runs:
   using: "composite"
   steps:
-    - name: Install uv
-      uses: astral-sh/setup-uv@v3
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
       with:
-        enable-cache: true
-        version: "0.4.23"
+        toolchain: stable
+        profile: minimal
+        override: true
+
+    # - name: Install uv
+    #   uses: astral-sh/setup-uv@v3
+    #   with:
+    #     enable-cache: true
+    #     version: "0.4.23"
+    - name: Install uv
+      shell: bash
+      run: cargo install --git https://github.com/astral-sh/uv --rev 0c445eb11d8b6caffe28e4a54cdbb744e1832235 uv
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
-        version: "0.4.20"
+        version: "0.4.21"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -17,7 +17,7 @@ runs:
     #     version: "0.4.23"
     - name: Install uv
       shell: bash
-      run: cargo install --git https://github.com/astral-sh/uv --rev beab67e2259dc21c444d827482c4fd13b03e308d uv
+      run: cargo install --git https://github.com/astral-sh/uv --rev 7730861bc5c6fb58ad402a396479f2cba6946110 uv
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -17,7 +17,7 @@ runs:
     #     version: "0.4.23"
     - name: Install uv
       shell: bash
-      run: cargo install --git https://github.com/astral-sh/uv --rev 0c445eb11d8b6caffe28e4a54cdbb744e1832235 uv
+      run: cargo install --git https://github.com/astral-sh/uv --rev beab67e2259dc21c444d827482c4fd13b03e308d uv
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,6 +7,7 @@ runs:
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
+        cache-local-path: ".cache"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
-        cache-local-path: ".cache"
+        version: "0.4.23"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
-        version: "0.4.22"
+        version: "0.4.23"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: astral-sh/setup-uv@v3
       with:
         enable-cache: true
-        version: "0.4.21"
+        version: "0.4.22"
 
     - name: Set up Python
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,29 +1,16 @@
 name: "Common steps to install and cache dependencies"
 
-inputs:
-  python-version:
-    description: "Python version to set up"
-    required: false
-    default: "3.12"
-
 runs:
   using: "composite"
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ inputs.python-version }}
-
     - name: Install uv
-      uses: yezz123/setup-uv@v4
-
-    - name: Cache project dependencies
-      uses: actions/cache@v4
+      uses: astral-sh/setup-uv@v3
       with:
-        path: ./.venv
-        key: deps-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('uv.lock') }}
-        restore-keys: |
-          deps-${{ runner.os }}-${{ inputs.python-version }}-
+        enable-cache: true
+
+    - name: Set up Python
+      shell: bash
+      run: uv python install
 
     - name: Install dependencies with uv
       shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -10,7 +10,9 @@ runs:
 
     - name: Set up Python
       shell: bash
-      run: uv python install
+      run: |
+        uv python install
+        echo "PYTHON_VERSION=$(uv run python -c 'import platform; print(platform.python_version())')" >> "$GITHUB_ENV"
 
     - name: Install dependencies with uv
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,12 +22,10 @@ jobs:
         with:
           path: ~/.cache/pre-commit/
           key: >
-            ${{ format('pre-commit-{0}-{1}',
-            env.PYTHON_VERSION,
+            ${{ format('pre-commit-{0}',
             hashFiles('.pre-commit-config.yaml')
             ) }}
           restore-keys: |
-            pre-commit-${{ env.PYTHON_VERSION }}-
             pre-commit-
 
       - name: Run pre-commit on all files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,11 @@ jobs:
         with:
           path: ~/.cache/pre-commit/
           key: >
-            ${{ format('pre-commit-{0}',
+            ${{ format('pre-commit-{0}-py{1}-{2}',
+            runner.os,
+            env.PYTHON_VERSION,
             hashFiles('.pre-commit-config.yaml')
             ) }}
-          restore-keys: |
-            pre-commit-
 
       - name: Run pre-commit on all files
         run: |


### PR DESCRIPTION
* Official workflow implements caching while current version doesn't add uv version to cache key. This may cause incompatible cache entries which can't be restored by newer versions of uv. Official implementation should handle such cases.
* This also simplifies workflows significantly.
* Also setup python using uv. This will use version specified in `pyproject.toml` and allows to remove it from workflows.