### PR TITLE
Publish in environment without twine

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,8 @@
 name: Publish new packages
 
+concurrency: release
+environment: release
+
 on:
   schedule:
     - cron: "20 0,12 * * *"
@@ -27,5 +30,3 @@ jobs:
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/update_stubs.py
+++ b/update_stubs.py
@@ -207,13 +207,8 @@ def publish_package(repo_root: Path) -> None:
     LOGGER.info("Publishing package...")
     subprocess.run(
         [
-            "uvx",
-            "twine",
-            "upload",
-            "--non-interactive",
-            "--disable-progress-bar",
-            "--skip-existing",
-            "dist/*",
+            "uv",
+            "publish",
         ],
         cwd=repo_root,
         check=True,
@@ -306,8 +301,6 @@ def generate_stubs(typed_paths: list[Path], repo_root: Path) -> None:
         f.write("\n".join(map(str, typed_paths)))
         f.close()
         command_args: list[str] = [
-            "uv",
-            "run",
             "stubgen",
             "--include-private",
             "-o",


### PR DESCRIPTION
`uv` can publish without `twine` now.

Migrate to trusted publisher as well.