### PR TITLE
Use custom stubgen version with further dataclass improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ source = "vcs"
 prerelease = "allow"
 
 [tool.uv.sources]
-# ddff8dab9ab70bf5ece09650d6b195bf434f7f15   Add --preserve-decorators option
-mypy = { git = "https://github.com/python/mypy", rev = "ddff8dab9ab70bf5ece09650d6b195bf434f7f15" }
+# https://github.com/python/mypy/pull/18430  Improve dataclass init signatures
+# 276189d69ec75cd597516140f4de6909abbc4e8a   Add --preserve-decorators option
+mypy = { git = "https://github.com/python/mypy", rev = "276189d69ec75cd597516140f4de6909abbc4e8a" }
 
 [tool.pylint.format]
 expected-line-ending-format = "LF"

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ requires-dist = [{ name = "homeassistant", specifier = "==2025.1.1" }]
 dev = [
     { name = "awesomeversion", specifier = ">=24.6.0" },
     { name = "codespell", specifier = ">=2.3.0" },
-    { name = "mypy", git = "https://github.com/python/mypy?rev=ddff8dab9ab70bf5ece09650d6b195bf434f7f15" },
+    { name = "mypy", git = "https://github.com/python/mypy?rev=276189d69ec75cd597516140f4de6909abbc4e8a" },
     { name = "pygithub", specifier = ">=2.4.0" },
     { name = "pylint", specifier = ">=3.3.1" },
     { name = "ruff", specifier = ">=0.7.0" },
@@ -1113,8 +1113,8 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.15.0+dev.ddff8dab9ab70bf5ece09650d6b195bf434f7f15"
-source = { git = "https://github.com/python/mypy?rev=ddff8dab9ab70bf5ece09650d6b195bf434f7f15#ddff8dab9ab70bf5ece09650d6b195bf434f7f15" }
+version = "1.15.0+dev.276189d69ec75cd597516140f4de6909abbc4e8a"
+source = { git = "https://github.com/python/mypy?rev=276189d69ec75cd597516140f4de6909abbc4e8a#276189d69ec75cd597516140f4de6909abbc4e8a" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },


### PR DESCRIPTION
Got another one. This time for dataclasses. `stubgen` currently generates empty `__init__` methods without annotations which are often just unnecessary. https://github.com/python/mypy/pull/18430 will remove those and keep the field specifier instead, i.e `field(default_factory=list)` which type checkers already know how to handle.

https://github.com/python/mypy/compare/master...cdce8p:stubgen-combined
https://github.com/python/mypy/compare/ccf05db67f6f99878c73eb902fc59a6f037b18a6...276189d69ec75cd597516140f4de6909abbc4e8a

https://github.com/KapJI/homeassistant-stubs/blob/ddcfffaa440df34e8019a27723459aa616841fc8/homeassistant-stubs/components/sensor/__init__.pyi#L21-L30