### PR TITLE
Use custom stubgen version with decorator improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,8 @@ source = "vcs"
 prerelease = "allow"
 
 [tool.uv.sources]
-# https://github.com/python/mypy/pull/18430  Improve dataclass init signatures
-# 276189d69ec75cd597516140f4de6909abbc4e8a   Add --preserve-decorators option
-mypy = { git = "https://github.com/python/mypy", rev = "276189d69ec75cd597516140f4de6909abbc4e8a" }
+# https://github.com/python/mypy/pull/18489  Include simple decorators in stub files
+mypy = { git = "https://github.com/python/mypy", rev = "a4ea153c4a979e833d5d56766b5a44199f77ea4d" }
 
 [tool.pylint.format]
 expected-line-ending-format = "LF"

--- a/update_stubs.py
+++ b/update_stubs.py
@@ -324,8 +324,6 @@ def generate_stubs(typed_paths: list[Path], repo_root: Path) -> None:
         command_args: list[str] = [
             "stubgen",
             "--include-private",
-            "--preserve-decorators",
-            "propcache.cached_property:propcache.under_cached_property",
             "-o",
             str(repo_root),
             f"@{f.name}",

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ requires-dist = [{ name = "homeassistant", specifier = "==2025.1.2" }]
 dev = [
     { name = "awesomeversion", specifier = ">=24.6.0" },
     { name = "codespell", specifier = ">=2.3.0" },
-    { name = "mypy", git = "https://github.com/python/mypy?rev=276189d69ec75cd597516140f4de6909abbc4e8a" },
+    { name = "mypy", git = "https://github.com/python/mypy?rev=a4ea153c4a979e833d5d56766b5a44199f77ea4d" },
     { name = "pygithub", specifier = ">=2.4.0" },
     { name = "pylint", specifier = ">=3.3.1" },
     { name = "ruff", specifier = ">=0.7.0" },
@@ -1113,8 +1113,8 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.15.0+dev.276189d69ec75cd597516140f4de6909abbc4e8a"
-source = { git = "https://github.com/python/mypy?rev=276189d69ec75cd597516140f4de6909abbc4e8a#276189d69ec75cd597516140f4de6909abbc4e8a" }
+version = "1.15.0+dev.a4ea153c4a979e833d5d56766b5a44199f77ea4d"
+source = { git = "https://github.com/python/mypy?rev=a4ea153c4a979e833d5d56766b5a44199f77ea4d#a4ea153c4a979e833d5d56766b5a44199f77ea4d" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },


### PR DESCRIPTION
https://github.com/python/mypy/pull/18430 was merged yesterday and I finally had the time to work on adding (simple) decorator support upstream in https://github.com/python/mypy/pull/18489. This will include the `propcache` decorator so that custom commit for the `--preserve-decorators` option is no longer necessary.

https://github.com/python/mypy/compare/master...cdce8p:stubgen-decorators-1
https://github.com/python/mypy/compare/68cffa7afe03d2b663aced9a70254e58704857db...a4ea153c4a979e833d5d56766b5a44199f77ea4d