### PR TITLE
Use outer uv in update_stubs.py

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Generate and publish new packages
-        run: uv run python update_stubs.py
+        run: UV_BIN_PATH=$(which uv) uv run python update_stubs.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/uv.lock
+++ b/uv.lock
@@ -871,7 +871,6 @@ wheels = [
 
 [[package]]
 name = "homeassistant-stubs"
-version = "2025.1.2.dev1+geb4da928.d20250110"
 source = { editable = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
`uv` inside virtualenv comes from home assistant dependencies and may be outdated and incompatible with version outside virtualenv.