### PR TITLE
Use upstream mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ source = "vcs"
 prerelease = "allow"
 
 [tool.uv.sources]
-# https://github.com/python/mypy/pull/18489  Include simple decorators in stub files
-mypy = { git = "https://github.com/python/mypy", rev = "a4ea153c4a979e833d5d56766b5a44199f77ea4d" }
+# TODO switch back to released versions with 1.16.0
+mypy = { git = "https://github.com/python/mypy", rev = "3ced11a43e75dd97554d5c7af78da296ee0d04ec" }
 
 [tool.pylint.format]
 expected-line-ending-format = "LF"

--- a/uv.lock
+++ b/uv.lock
@@ -894,7 +894,7 @@ requires-dist = [{ name = "homeassistant", specifier = "==2025.1.4" }]
 dev = [
     { name = "awesomeversion", specifier = ">=24.6.0" },
     { name = "codespell", specifier = ">=2.3.0" },
-    { name = "mypy", git = "https://github.com/python/mypy?rev=a4ea153c4a979e833d5d56766b5a44199f77ea4d" },
+    { name = "mypy", git = "https://github.com/python/mypy?rev=3ced11a43e75dd97554d5c7af78da296ee0d04ec" },
     { name = "pygithub", specifier = ">=2.4.0" },
     { name = "pylint", specifier = ">=3.3.1" },
     { name = "ruff", specifier = ">=0.7.0" },
@@ -1112,8 +1112,8 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.15.0+dev.a4ea153c4a979e833d5d56766b5a44199f77ea4d"
-source = { git = "https://github.com/python/mypy?rev=a4ea153c4a979e833d5d56766b5a44199f77ea4d#a4ea153c4a979e833d5d56766b5a44199f77ea4d" }
+version = "1.16.0+dev.3ced11a43e75dd97554d5c7af78da296ee0d04ec"
+source = { git = "https://github.com/python/mypy?rev=3ced11a43e75dd97554d5c7af78da296ee0d04ec#3ced11a43e75dd97554d5c7af78da296ee0d04ec" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },


### PR DESCRIPTION
https://github.com/python/mypy/pull/18489 was merged last night. All stubgen improvements so far are now included in upstream mypy.

https://github.com/python/mypy/commit/3ced11a43e75dd97554d5c7af78da296ee0d04ec
https://github.com/python/mypy/commits/master/

> [!NOTE]
> The release branch for `1.15.0` was cut a few days ago, so the decorator improvements will only be included in `1.16.0`.